### PR TITLE
TryAuthOpen does not mutate config input anymore

### DIFF
--- a/agency/client/client.go
+++ b/agency/client/client.go
@@ -64,10 +64,14 @@ func TryAuthOpen(jwtToken string, conf *rpc.ClientCfg) (c Conn) {
 	if conf == nil {
 		panic(errors.New("conf cannot be nil"))
 	}
-	conf.JWT = jwtToken
-	conn, err := rpc.ClientConn(*conf)
+
+	lc := *conf
+	lc.JWT = jwtToken
+
+	conn, err := rpc.ClientConn(lc)
 	err2.Check(err)
-	return Conn{ClientConn: conn, cfg: conf}
+
+	return Conn{ClientConn: conn, cfg: &lc}
 }
 
 func TryOpen(user string, conf *rpc.ClientCfg) (c Conn) {


### PR DESCRIPTION
- maybe better would be to send Cfg as a value, but now we don't need to change the function signature and that's why callers.