### PR TITLE
Update go to 1.18

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 65%
+        target: 15%
         threshold: 3%
     patch:
       default:

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -1,5 +1,5 @@
 name: push-base-image
-on:  
+on:
   push:
     branches:
       - base-image
@@ -31,10 +31,10 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/findy-base:alpine-3.13
+          tags: ghcr.io/${{ github.repository_owner }}/findy-base:alpine-3.15
           context: ./infra/aws
           file: ./infra/aws/Dockerfile.alpine
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/findy-base:alpine-3.13
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/findy-base:alpine-3.15
           cache-to: type=inline
 
   push-indy-ubuntu:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.18.x
       - name: checkout
         uses: actions/checkout@v2
       - name: test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/findy-network/findy-common-go
 
-go 1.16
+go 1.18
 
 require (
 	github.com/auth0/go-jwt-middleware v1.0.0
@@ -8,18 +8,29 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/uuid v1.2.0
-	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
-	github.com/kr/text v0.2.0 // indirect
 	github.com/lainio/err2 v0.7.0
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/bbolt v1.3.5
-	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 	golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c
 	google.golang.org/grpc v1.35.0
-	google.golang.org/grpc/examples v0.0.0-20210304020650-930c79186c99 // indirect
 	google.golang.org/protobuf v1.25.0
+)
+
+require (
+	cloud.google.com/go v0.65.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
+	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 // indirect
+	google.golang.org/grpc/examples v0.0.0-20210304020650-930c79186c99 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
-github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -147,8 +146,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/lainio/err2 v0.6.1 h1:SbseiR4W5oL63qlmJfZpXvpRQRU7SeNsxYA1oAEhlX0=
-github.com/lainio/err2 v0.6.1/go.mod h1:v7nQS9Yes0LMZFlRJqyfGPFYvfbRUeWh+e0jN9tpEdk=
 github.com/lainio/err2 v0.7.0 h1:AbWoIiUqaA9msfW2CgbMLtpnjQnE6XxJ2GIhsFbMKSA=
 github.com/lainio/err2 v0.7.0/go.mod h1:+ogMLB0Z5wEp2/rHY/ykSaYcdnaLqIzgt1RrjMTFvdM=
 github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f/go.mod h1:AmCV4WB3cDMZqgPk+OUQKumliiQS4ZYsBt3AXekyuAU=
@@ -308,7 +305,6 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/infra/aws/Dockerfile.alpine
+++ b/infra/aws/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.18-alpine3.15
 
 WORKDIR /work
 
@@ -9,7 +9,7 @@ COPY . ./
 
 RUN go build -o /go/bin/s3-copy
 
-FROM alpine:3.13
+FROM alpine:3.15
 
 COPY --from=0 /go/bin/s3-copy /s3-copy
 

--- a/infra/aws/Dockerfile.indy.ubuntu
+++ b/infra/aws/Dockerfile.indy.ubuntu
@@ -1,4 +1,4 @@
-FROM golang:1.16-buster AS s3-builder
+FROM golang:1.18-buster AS s3-builder
 
 WORKDIR /work
 

--- a/infra/aws/go.mod
+++ b/infra/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/findy-network/findy-common-go/infra/aws
 
-go 1.16
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.3.0
@@ -8,4 +8,16 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.1.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.3.0
 	github.com/lainio/err2 v0.6.1
+)
+
+require (
+	github.com/aws/aws-sdk-go-v2/credentials v1.1.3 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.0.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.2.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.1.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.2.0 // indirect
+	github.com/aws/smithy-go v1.2.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )


### PR DESCRIPTION
* Update go to 1.18
* Adjust also the coverage target: with the correct coverage measurement style, all project files are counted to the total coverage. That drops the current coverage, since we have a lot of files with no tests in this repository. Most of those are tested through `findy-agent` unit tests.