### PR TITLE
Err2 annotate to return

### DIFF
--- a/agency/client/chat/bot.go
+++ b/agency/client/chat/bot.go
@@ -1,10 +1,10 @@
+// Package chat implments state-machine based chat bots
 package chat
 
 import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -26,13 +26,13 @@ type Bot struct {
 
 func LoadFSMMachineData(fName string, r io.Reader) (m fsm.MachineData, err error) {
 	defer err2.Return(&err)
-	data := try.To1(ioutil.ReadAll(r))
+	data := try.To1(io.ReadAll(r))
 	return fsm.MachineData{FType: fName, Data: data}, nil
 }
 
 func LoadFSM(fName string, r io.Reader) (m *fsm.Machine, err error) {
 	defer err2.Return(&err)
-	data := try.To1(ioutil.ReadAll(r))
+	data := try.To1(io.ReadAll(r))
 	m = loadFSMData(fName, data)
 	try.To(m.Initialize())
 	return m, nil
@@ -51,7 +51,7 @@ func loadFSMData(fName string, data []byte) *fsm.Machine {
 func SaveFSM(m *fsm.Machine, fName string) (err error) {
 	defer err2.Return(&err)
 	data := marshalFSM(fName, m)
-	try.To(ioutil.WriteFile(fName, data, 0644))
+	try.To(os.WriteFile(fName, data, 0644))
 	return nil
 }
 
@@ -82,7 +82,7 @@ loop:
 		select {
 		case status, ok := <-ch:
 			if !ok {
-				glog.V(2).Infoln("closed from server")
+				glog.V(20).Infoln("closed from server")
 				break loop
 			}
 			glog.V(5).Infoln("listen status:",
@@ -92,7 +92,7 @@ loop:
 			chat.Status <- status
 		case question, ok := <-questionCh:
 			if !ok {
-				glog.V(2).Infoln("closed from server")
+				glog.V(20).Infoln("closed from server")
 				break loop
 			}
 			glog.V(5).Infoln("listen question status:",
@@ -102,7 +102,6 @@ loop:
 			chat.Question <- question
 		case <-intCh:
 			cancel()
-			glog.V(2).Infoln("interrupted by user, cancel() called")
 		}
 	}
 }

--- a/agency/client/client.go
+++ b/agency/client/client.go
@@ -1,3 +1,4 @@
+// Package client implements helpers for gRPC client connection to Agency
 package client
 
 import (
@@ -79,7 +80,8 @@ func TryAuthOpen(jwtToken string, conf *rpc.ClientCfg) (c Conn) {
 	return TryAuthOpenWithSleep(jwtToken, conf, nil)
 }
 
-//nolintlint
+// TryAuthOpenWithSleep opens authorized gRPC connection with sleep time.
+// nolintlint
 func TryAuthOpenWithSleep(
 	jwtToken string,
 	conf *rpc.ClientCfg,
@@ -478,7 +480,9 @@ func (conn Conn) ListenStatus(
 // is identifed by ClientID. NOTE! This function handles connection errors by
 // itself i.e. it tries to reopen error connnections until its terminated by
 // ctx.Cancel. NOTE! The function filters KEEPALIVE messages.
-func (conn Conn) ListenStatusAndRetry( // nolint:dupl
+//
+//nolint:dupl
+func (conn Conn) ListenStatusAndRetry(
 	ctx context.Context,
 	client *agency.ClientID,
 	cOpts ...grpc.CallOption,
@@ -560,7 +564,7 @@ func (conn Conn) ListenStatusErr(
 // identifed by ClientID. NOTE! This function handles connection errors by
 // itself i.e. it tries to reopen error connnections until its terminated by
 // ctx.Cancel. NOTE! The function filters KEEPALIVE messages.
-func (conn Conn) WaitAndRetry( // nolint:dupl
+func (conn Conn) WaitAndRetry( //nolint:dupl
 	ctx context.Context,
 	client *agency.ClientID,
 	cOpts ...grpc.CallOption,

--- a/agency/fsm/plantuml.go
+++ b/agency/fsm/plantuml.go
@@ -21,10 +21,11 @@ func GenerateURL(subPath string, m *Machine) (URL *url.URL, err error) {
 }
 
 // translate translates standard base64 string to plantuml's version:
-//  normal base64:n
-//  ABCDEFGHIJ KLMNOPQRSTUVWXYZ abcdefghij klmnopqrstuvwxyz 0123456789 +/
-//  plant's 'close' to base64:
-//  0123456789 ABCDEFGHIJKLMNOP QRSTUVWXYZ abcdefghijklmnop qrstuvwxyz -_
+//
+//	normal base64:n
+//	ABCDEFGHIJ KLMNOPQRSTUVWXYZ abcdefghij klmnopqrstuvwxyz 0123456789 +/
+//	plant's 'close' to base64:
+//	0123456789 ABCDEFGHIJKLMNOP QRSTUVWXYZ abcdefghijklmnop qrstuvwxyz -_
 func translate(b64 string) string {
 	trans := func(r rune) rune {
 		switch {

--- a/agency/fsm/plantuml.go
+++ b/agency/fsm/plantuml.go
@@ -12,7 +12,7 @@ import (
 )
 
 func GenerateURL(subPath string, m *Machine) (URL *url.URL, err error) {
-	defer err2.Annotate("generate plantuml URL", &err)
+	defer err2.Returnf(&err, "generate plantuml URL")
 	rawPlantModel := m.String()
 	deflated := tryDeflate([]byte(rawPlantModel))
 	b64 := base64.RawStdEncoding.EncodeToString(deflated[2 : len(deflated)-4])

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -14,7 +14,9 @@ import (
 )
 
 // PrefixName builds a new prefixed file name. The file name is in format:
-//  prefix_file.name
+//
+//	prefix_file.name
+//
 // If prefix is empty the returned string starts with _.
 func PrefixName(prefix, name string) string {
 	dir, file := filepath.Split(name)

--- a/crypto/db/db.go
+++ b/crypto/db/db.go
@@ -35,7 +35,7 @@ type Mgd struct {
 // and opening of the DB which is needed that DB can operate and backups can be
 // taken without explicitly closing the database.
 func (m *Mgd) operate(f func(db *bolt.DB) error) (err error) {
-	defer err2.Annotate("db operate", &err)
+	defer err2.Returnf(&err, "db operate")
 
 	m.l.Lock()
 	defer m.l.Unlock()
@@ -79,7 +79,7 @@ func (m *Mgd) open() (err error) {
 	m.db = try.To1(bolt.Open(m.Filename, 0600, nil))
 
 	try.To(m.db.Update(func(tx *bolt.Tx) (err error) {
-		defer err2.Annotate("create buckets", &err)
+		defer err2.Returnf(&err, "create buckets")
 
 		for _, bucket := range m.Buckets {
 			try.To1(tx.CreateBucketIfNotExists(bucket))
@@ -143,7 +143,7 @@ func (m *Mgd) backupName() string {
 // index use Data type's operators to encrypt and hash data on the fly.
 func (db *Mgd) AddKeyValueToBucket(bucket []byte, keyValue, index *Data) (err error) {
 	return db.operate(func(DB *bolt.DB) error {
-		defer err2.Annotate("add key", &err)
+		defer err2.Returnf(&err, "add key")
 
 		try.To(DB.Update(func(tx *bolt.Tx) (err error) {
 			defer err2.Return(&err)
@@ -166,7 +166,7 @@ func AddKeyValueToBucket(bucket []byte, keyValue, index *Data) (err error) {
 // The index uses Data type's operators to encrypt and hash data on the fly.
 func (db *Mgd) RmKeyValueFromBucket(bucket []byte, index *Data) (err error) {
 	return db.operate(func(DB *bolt.DB) error {
-		defer err2.Annotate("rm key", &err)
+		defer err2.Returnf(&err, "rm key")
 
 		try.To(DB.Update(func(tx *bolt.Tx) (err error) {
 			defer err2.Return(&err)
@@ -208,7 +208,7 @@ func (db *Mgd) GetKeyValueFromBucket(
 	found bool,
 	err error,
 ) {
-	defer err2.Annotate("get value", &err)
+	defer err2.Returnf(&err, "get value")
 
 	try.To(db.operate(func(DB *bolt.DB) error {
 		try.To(DB.View(func(tx *bolt.Tx) (err error) {
@@ -258,7 +258,7 @@ func (db *Mgd) GetAllValuesFromBucket(
 	values [][]byte,
 	err error,
 ) {
-	defer err2.Annotate("get all values", &err)
+	defer err2.Returnf(&err, "get all values")
 
 	values = make([][]byte, 0)
 
@@ -323,7 +323,7 @@ func Backup() (did bool, err error) {
 // Backup takes backup copy of the database. Before backup the database is
 // closed automatically and only dirty databases are backed up.
 func (db *Mgd) Backup() (did bool, err error) {
-	defer err2.Annotate("backup", &err)
+	defer err2.Returnf(&err, "backup")
 
 	db.l.Lock()
 	defer db.l.Unlock()
@@ -354,7 +354,7 @@ func Wipe() (err error) {
 
 // Wipe removes the whole database and its master file.
 func (db *Mgd) Wipe() (err error) {
-	defer err2.Annotate("wipe", &err)
+	defer err2.Returnf(&err, "wipe")
 
 	db.l.Lock()
 	defer db.l.Unlock()

--- a/dto/dto.go
+++ b/dto/dto.go
@@ -1,3 +1,4 @@
+// Package dto is for data transfer objects.
 package dto
 
 import (
@@ -76,9 +77,10 @@ func ToGOB(dto interface{}) []byte {
 
 // FromGOB reads object from bytes. Remember pass a pointer to preallocated
 // object of the right type.
-//  p := &PSM{}
-//  dto.FromGOB(d, p)
-//  return p
+//
+//	p := &PSM{}
+//	dto.FromGOB(d, p)
+//	return p
 func FromGOB(data []byte, dto interface{}) {
 	network := bytes.NewReader(data)
 	dec := gob.NewDecoder(network)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 
 	"github.com/findy-network/findy-common-go/jwt"
 	"github.com/golang/glog"
@@ -79,7 +79,7 @@ func ClientConn(cfg ClientCfg) (conn *grpc.ClientConn, err error) {
 func loadClientTLSFromFile(pw *PKI) (creds credentials.TransportCredentials, err error) {
 	defer err2.Return(&err)
 
-	caCert := try.To1(ioutil.ReadFile(pw.Server.CertFile))
+	caCert := try.To1(os.ReadFile(pw.Server.CertFile))
 	rootCAs := x509.NewCertPool()
 	rootCAs.AppendCertsFromPEM(caCert)
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -5,8 +5,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 
 	"github.com/findy-network/findy-common-go/jwt"
 	"github.com/golang/glog"
@@ -104,7 +104,7 @@ func PrepareServe(cfg *ServerCfg) (s *grpc.Server, lis net.Listener, err error) 
 func loadTLSCredentials(pw *PKI) (creds credentials.TransportCredentials, err error) {
 	defer err2.Return(&err)
 
-	caCert := try.To1(ioutil.ReadFile(pw.Client.CertFile))
+	caCert := try.To1(os.ReadFile(pw.Client.CertFile))
 	rootCAs := x509.NewCertPool()
 	rootCAs.AppendCertsFromPEM(caCert)
 

--- a/std/didexchange/invitation/models.go
+++ b/std/didexchange/invitation/models.go
@@ -13,7 +13,6 @@ import (
 //
 // Invitation defines DID exchange invitation message
 // https://github.com/hyperledger/aries-rfcs/tree/master/features/0023-did-exchange#0-invitation-to-exchange
-//
 type Invitation struct {
 	// the Image URL of the connection invitation
 	ImageURL string `json:"imageUrl,omitempty"`

--- a/std/didexchange/invitation/translate.go
+++ b/std/didexchange/invitation/translate.go
@@ -21,7 +21,7 @@ func decodeB64(str string) ([]byte, error) {
 }
 
 func Translate(s string) (i Invitation, err error) {
-	defer err2.Annotate("invitation translate", &err)
+	defer err2.Returnf(&err, "invitation translate")
 
 	u, err := url.Parse(strings.TrimSpace(s))
 
@@ -41,7 +41,7 @@ func Translate(s string) (i Invitation, err error) {
 }
 
 func Build(inv Invitation) (s string, err error) {
-	defer err2.Annotate("invitation build", &err)
+	defer err2.Returnf(&err, "invitation build")
 
 	b := try.To1(json.Marshal(inv))
 	return prefix + base64.RawURLEncoding.EncodeToString(b), nil


### PR DESCRIPTION
- `err2.Annotate` functions to `err2.Returnf`
- `err2.Annotate` will be obsolete and `err2.Returnf` is much better for refactoring and makes better code