### PR TITLE
terminate fsm and cleanup trace logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TEST_TIMEOUT?="10s"
+
 API_BRANCH=$(shell ./scripts/branch.sh ../findy-agent-api/)
 SRC_ROOT=$(PWD)/../../..
 IDL_PATH=../findy-agent-api/idl/v1
@@ -53,10 +55,13 @@ lint_e:
 	@$(GOPATH)/bin/golint ./... | grep -v export | cat
 
 test:
-	go test -v -p 1 -failfast ./...
+	go test -timeout $(TEST_TIMEOUT) -v -p 1 -failfast ./...
+
+test_fsm:
+	go test -timeout $(TEST_TIMEOUT) -v -p 1 -failfast ./agency/fsm/... -args -logtostderr -v=10
 
 logged_test:
-	go test -v -p 1 -failfast ./... -args -logtostderr=true -v=10
+	go test -timeout $(TEST_TIMEOUT) -v -p 1 -failfast ./... -args -logtostderr -v=10
 
 test_cov_out:
 	go test -p 1 -failfast \

--- a/agency/client/chat/bot.go
+++ b/agency/client/chat/bot.go
@@ -75,7 +75,7 @@ func (b Bot) Run(intCh chan os.Signal) {
 
 	chat.Machine = b.MachineData
 
-	go chat.Multiplexer(b.Conn)
+	go chat.Multiplexer(b.Conn, intCh)
 
 loop:
 	for {

--- a/agency/client/chat/chat/chat.go
+++ b/agency/client/chat/chat/chat.go
@@ -64,9 +64,9 @@ var (
 )
 
 // Multiplexer is a goroutine function to started multiplex all the
-// conversations an agent is currently having. It takes gRPC connection handle
-// and signaling channel as an arguments. Interrupt channel is need to tell when
-// a FSM has reached to the end. Note. Some state machines do that never.
+// conversations an agent is currently having. It takes a gRPC connection handle
+// and a signaling channel as an arguments. The interrupt channel is needed to tell when
+// a FSM has reached to the end. Note. Some state machines never do that.
 func Multiplexer(conn client.Conn, intCh chan<- os.Signal) {
 	glog.V(3).Infoln("starting multiplexer", Machine.FType)
 	termChan := make(fsm.TerminateChan, 1)
@@ -107,9 +107,9 @@ func Multiplexer(conn client.Conn, intCh chan<- os.Signal) {
 			}
 			c.QuestionChan <- question
 		case <-termChan:
-			// machine has reached its terminate state let's signal it to
-			// outside. In future we could offer API to what to send to
-			// intCh. SIGTERM is very good compromise in K8s, etc.
+			// machine has reached its terminate state. Let's signal it to
+			// outside. In future we could offer an API to what to send to
+			// the intCh. SIGTERM is very good compromise in K8s, etc.
 			glog.V(1).Infoln("<- FSM Terminate signal received")
 			intCh <- syscall.SIGTERM
 			glog.V(1).Infoln("-> signaled SIGTERM")

--- a/agency/client/client.go
+++ b/agency/client/client.go
@@ -492,7 +492,7 @@ func (conn Conn) ListenStatusAndRetry(
 	sch = make(chan *agency.AgentStatus)
 	go func() {
 		// catch all because worker
-		defer err2.CatchTrace(func(err error) {
+		defer err2.Catch(func(err error) {
 			glog.Warning(err)
 		})
 
@@ -574,7 +574,7 @@ func (conn Conn) WaitAndRetry( //nolint:dupl
 	ch = make(chan *agency.Question)
 	go func() {
 		// Catch all, panics as well because this is worker
-		defer err2.CatchTrace(func(err error) {
+		defer err2.Catch(func(err error) {
 			glog.Warning(err)
 		})
 
@@ -669,7 +669,7 @@ func transportStatus(
 	statusCh chan<- *agency.AgentStatus,
 	errCh chan<- error,
 ) {
-	defer err2.CatchTrace(func(err error) {
+	defer err2.Catch(func(err error) {
 		glog.V(1).Infoln("WARNING: error when reading response:", err)
 		if errCh != nil {
 			errCh <- err
@@ -697,7 +697,7 @@ func transportWait(
 	statusCh chan<- *agency.Question,
 	errCh chan<- error,
 ) {
-	defer err2.CatchTrace(func(err error) {
+	defer err2.Catch(func(err error) {
 		glog.V(1).Infoln("WARNING: error when reading response:", err)
 		if errCh != nil {
 			errCh <- err
@@ -729,7 +729,7 @@ func (conn Conn) PSMHook(ctx context.Context, cOpts ...grpc.CallOption) (ch chan
 	stream := try.To1(opsClient.PSMHook(ctx, &ops.DataHook{ID: utils.UUID()}, cOpts...))
 	glog.V(3).Infoln("successful start of listen PSM hook id:")
 	go func() {
-		defer err2.CatchTrace(func(err error) {
+		defer err2.Catch(func(err error) {
 			glog.V(1).Infoln("WARNING: error when reading response:", err)
 			close(statusCh)
 		})
@@ -755,7 +755,7 @@ func (conn Conn) doRun(ctx context.Context, protocol *agency.Protocol) (ch chan 
 	stream := try.To1(c.Run(ctx, protocol))
 	glog.V(3).Infoln("successful start of:", protocol.TypeID)
 	go func() {
-		defer err2.CatchTrace(func(err error) {
+		defer err2.Catch(func(err error) {
 			glog.V(3).Infoln("err when reading response", err)
 			close(statusCh)
 		})

--- a/agency/fsm/fsm.go
+++ b/agency/fsm/fsm.go
@@ -426,7 +426,7 @@ func padStr(s string) string {
 func (m *Machine) String() string {
 	w := new(bytes.Buffer)
 	fmt.Fprintf(w, "title %s\n", m.Name)
-	fmt.Fprintf(w, "[*] -> %s\n", m.Initial.Target)
+	fmt.Fprintf(w, "[*] --> %s\n", m.Initial.Target)
 	for stateName, state := range m.States {
 		fmt.Fprintf(w, "state \"%s\" as %s\n", padStr(stateName), stateName)
 		for _, transition := range state.Transitions {
@@ -437,7 +437,12 @@ func (m *Machine) String() string {
 			}
 			fmt.Fprintln(w)
 		}
-		fmt.Fprintln(w)
+		glog.V(10).Infof("terminate: %s -> %v", stateName, state.Terminate)
+		if state.Terminate {
+			fmt.Fprintf(w, "%s --> [*]\n", stateName)
+		} else {
+			fmt.Fprintln(w)
+		}
 	}
 	return w.String()
 }

--- a/agency/fsm/fsm.go
+++ b/agency/fsm/fsm.go
@@ -645,7 +645,7 @@ func NotificationTypeID(typeName string) NotificationType {
 	if _, ok := notificationTypeID[typeName]; ok {
 		return NotificationType(notificationTypeID[typeName])
 	} else if _, ok := QuestionTypeID[typeName]; ok {
-		return NotificationType(8) * NotificationType(QuestionTypeID[typeName])
+		return NotificationType(10) * NotificationType(QuestionTypeID[typeName])
 	}
 	glog.V(10).Infof("unknown type: \"%v\" setting zero", typeName)
 	return 0

--- a/agency/fsm/plantuml_test.go
+++ b/agency/fsm/plantuml_test.go
@@ -20,6 +20,8 @@ func TestGenerateURL(t *testing.T) {
 	}{
 		{name: "simple", args: args{"svg", &machine}, wantErr: false,
 			wantURL: simpleURL},
+		{name: "simpleTerminate", args: args{"svg", &machineTerminates}, wantErr: false,
+			wantURL: simpleURL},
 		{name: "proof machine", args: args{"svg", &showProofMachine}, wantErr: false,
 			wantURL: proofMachineURL},
 	}
@@ -30,6 +32,7 @@ func TestGenerateURL(t *testing.T) {
 				t.Errorf("GenerateURL() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+			// not very good test
 			if gotURL == nil || gotURL.Host != tt.wantURL.Host || !gotURL.IsAbs() {
 				t.Errorf("GenerateURL() gotURL = %v, want %v", gotURL, tt.wantURL)
 			}

--- a/crypto/db/db.go
+++ b/crypto/db/db.go
@@ -313,7 +313,7 @@ func (db *Mgd) BackupTicker(interval time.Duration) (done chan<- struct{}) {
 	ticker := time.NewTicker(interval)
 	doneCh := make(chan struct{})
 	go func() {
-		defer err2.CatchTrace(func(err error) {
+		defer err2.Catch(func(err error) {
 			glog.Error(err)
 		})
 		for {

--- a/infra/aws/main.go
+++ b/infra/aws/main.go
@@ -14,7 +14,7 @@ func _(msg string, args ...interface{}) {
 }
 
 func main() {
-	defer err2.CatchTrace(func(err error) {
+	defer err2.Catch(func(err error) {
 		fmt.Fprintln(os.Stderr, err)
 	})
 

--- a/integration/grpc_test.go
+++ b/integration/grpc_test.go
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 
 func setUp() {
 	err2.SetTracers(os.Stderr)
-	defer err2.CatchTrace(func(err error) {
+	defer err2.Catch(func(err error) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	})


### PR DESCRIPTION
- new test goals
- Termination states in FSMs, API to signal process with SIGTERM
- err2.CatchTrace -> err2.Catch
- documentation and better logging for new terminate state feature
- rendering FSM termination in plantuml
- typos in documentation
- typo fixed
